### PR TITLE
Generalized config importing

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ export class BasePlugin {
     this.uploads = options.uploads || [];
     this.description = options.description;
     this.makeRequest = options.makeRequest;
+    this.app = options.app;
+
     if(!this.description) throw new Error('Description is a required configuration field');
     this.validate()
   }


### PR DESCRIPTION
Now the plugins config would look like this:

```
plugins:
  development:
    - googleSearch
  settings:
    googleSearch:
      google_search_api_key: XXX
      google_search_api_id: XXX
```
      
 where the settings variable which matches the plugin name will be loaded into the plugin object.
 so from within the googleSearch plugin, the keys can be accessed with `this.google_search_api_key`, for instance